### PR TITLE
Offboard config

### DIFF
--- a/games/1817.json
+++ b/games/1817.json
@@ -8,6 +8,7 @@
     "titleSize": 165,
     "subtitleSize": 17,
     "currency": "$#",
+    "capitalization": "incremental",
     "extraStationTokens": 4
   },
   "links": {

--- a/games/1846.json
+++ b/games/1846.json
@@ -6,6 +6,7 @@
     "background": "orange",
     "marketTokens": 2,
     "extraStationTokens": 3,
+    "capitalization": "incremental",
     "currency": "$#"
   },
   "links": {

--- a/games/1846.json
+++ b/games/1846.json
@@ -1022,13 +1022,13 @@
             "side": 1
           }
         ],
-        "groups": ["Buffalo", "East"],
         "offBoardRevenue": {
           "angle": 150,
           "percent": 1,
           "name": {
             "name": "Buffalo"
           },
+          "groups": ["Buffalo", "East"],
           "revenues": [
             {
               "color": "yellow",

--- a/games/1846.json
+++ b/games/1846.json
@@ -1187,9 +1187,7 @@
         ],
         "names": [
           {
-            "name": {
-              "name": "Homewood"
-            },
+            "name": "Homewood",
             "angle": 33,
             "percent": 0.65
           }

--- a/games/1846.json
+++ b/games/1846.json
@@ -987,8 +987,20 @@
             "label": "E"
           }
         ],
+        "offBoardRevenue": {
+          "hidden": true,
+          "revenues": [
+            {
+              "color": "yellow",
+              "cost": "30"
+            },
+            {
+              "color": "brown",
+              "cost": "60"
+            }
+          ]
+        },
         "removeBorders": [5],
-        "encoding": "o=r:yellow_30|brown_60,h:1;p=a:0,b:_0;b=e:5",
         "hexes": ["C21"]
       },
       {
@@ -1025,7 +1037,6 @@
           ]
         },
         "removeBorders": [2],
-        "encoding": "o=r:yellow_30|brown_60;p=a:1,b:_0;l=E;b=e:2",
         "hexes": ["D22"]
       },
       {
@@ -1228,8 +1239,20 @@
             "side": 1
           }
         ],
+        "offBoardRevenue": {
+          "hidden": true,
+          "revenues": [
+            {
+              "color": "yellow",
+              "cost": "30"
+            },
+            {
+              "color": "brown",
+              "cost": "70"
+            }
+          ]
+        },
         "removeBorders": [6],
-        "encoding": "o=r:yellow_30|brown_70,h:1;p=a:1,b:_0;b=e:0",
         "hexes": ["F22"]
       },
       {
@@ -1386,7 +1409,6 @@
           ]
         },
         "removeBorders": [3],
-        "encoding": "o=r:yellow_30|brown_70;p=a:1,b:_0;p=a:2,b:_0;l=E;b=e:3",
         "hexes": ["G21"]
       },
       {

--- a/games/1846.json
+++ b/games/1846.json
@@ -868,7 +868,7 @@
             "percent": 0.75
           }
         ],
-        "encoding": "c=r:10;c=r:10;c=r:10;c=r:10;p=a:0,b:_0;p=a:3,b:_1;p=a:4,b:_2;p=a:5,b:_3;l=Chi",
+        "encoding": "c=r:10,g:Chicago;c=r:10,g:Chicago;c=r:10,g:Chicago;c=r:10,g:Chicago;p=a:0,b:_0;p=a:3,b:_1;p=a:4,b:_2;p=a:5,b:_3;l=Chi",
         "icons": [
           {
             "type": "meat",

--- a/games/1846.json
+++ b/games/1846.json
@@ -865,7 +865,7 @@
             "percent": 0.75
           }
         ],
-        "encoding": "c=r:10;c=r:10;c=r:10;c=r:10;p=a:2,b:_0;p=a:3,b:_1;p=a:4,b:_2;p=a:5,b:_3;l=Chi",
+        "encoding": "c=r:10;c=r:10;c=r:10;c=r:10;p=a:0,b:_0;p=a:3,b:_1;p=a:4,b:_2;p=a:5,b:_3;l=Chi",
         "icons": [
           {
             "type": "meat",
@@ -952,7 +952,7 @@
               }
             ],
             "name": {
-              "name": "ERIE",
+              "name": "Erie",
               "reverse": true,
               "offset": 63
             }
@@ -987,7 +987,7 @@
           }
         ],
         "removeBorders": [5],
-        "encoding": "o=yellow_30|brown_60;p=a:5,b:_0;l=E",
+        "encoding": "o=r:yellow_30|brown_60;p=a:0,b:_0;l=E",
         "hexes": ["C21"]
       },
       {
@@ -1024,7 +1024,7 @@
           ]
         },
         "removeBorders": [2],
-        "encoding": "o=yellow_30|brown_60;p=a:0,b:_0;l=E",
+        "encoding": "o=r:yellow_30|brown_60;p=a:1,b:_0;l=E",
         "hexes": ["D22"]
       },
       {
@@ -1186,7 +1186,9 @@
         ],
         "names": [
           {
-            "name": "Homewood",
+            "name": {
+              "name": "Homewood"
+            },
             "angle": 33,
             "percent": 0.65
           }
@@ -1228,7 +1230,7 @@
           }
         ],
         "removeBorders": [6],
-        "encoding": "o=yellow_30|brown_70;p=a:0,b:_0;l=E",
+        "encoding": "o=r:yellow_30|brown_70;p=a:1,b:_0;l=E",
         "hexes": ["F22"]
       },
       {
@@ -1385,7 +1387,7 @@
           ]
         },
         "removeBorders": [3],
-        "encoding": "o=yellow_30|brown_70;p=a:0,b:_0;p=a:1,b:_0;l=E",
+        "encoding": "o=r:yellow_30|brown_70;p=a:1,b:_0;p=a:2,b:_0;l=E",
         "hexes": ["G21"]
       },
       {

--- a/games/1846.json
+++ b/games/1846.json
@@ -661,6 +661,7 @@
           "name": {
             "name": "Sarnia"
           },
+          "groups": ["East"],
           "revenues": [
             {
               "color": "yellow",
@@ -820,6 +821,7 @@
           "name": {
             "name": "Windsor"
           },
+          "groups": ["East"],
           "revenues": [
             {
               "color": "yellow",
@@ -989,6 +991,7 @@
         ],
         "offBoardRevenue": {
           "hidden": true,
+          "groups": ["Buffalo", "East"],
           "revenues": [
             {
               "color": "yellow",
@@ -1019,6 +1022,7 @@
             "side": 1
           }
         ],
+        "groups": ["Buffalo", "East"],
         "offBoardRevenue": {
           "angle": 150,
           "percent": 1,
@@ -1138,6 +1142,7 @@
           "name": {
             "name": "Binghamton"
           },
+          "groups": ["East"],
           "revenues": [
             {
               "color": "yellow",
@@ -1241,6 +1246,7 @@
         ],
         "offBoardRevenue": {
           "hidden": true,
+          "groups": ["Pittsburgh", "East"],
           "revenues": [
             {
               "color": "yellow",
@@ -1397,6 +1403,7 @@
           "name": {
             "name": "Pittsburgh"
           },
+          "groups": ["Pittsburgh", "East"],
           "revenues": [
             {
               "color": "yellow",
@@ -1460,6 +1467,7 @@
           "name": {
             "name": "Cumberland"
           },
+          "groups": ["East"],
           "revenues": [
             {
               "color": "yellow",
@@ -1636,6 +1644,7 @@
           "name": {
             "name": "Charleston"
           },
+          "groups": ["East"],
           "revenues": [
             {
               "color": "yellow",

--- a/games/1846.json
+++ b/games/1846.json
@@ -270,18 +270,21 @@
       "name": "1",
       "train": "2",
       "limit": 4,
+      "rounds": 2,
       "tiles": "yellow"
     },
     {
       "name": "2",
       "train": ["3/5", "4"],
       "limit": 4,
+      "rounds": 2,
       "tiles": "green"
     },
     {
       "name": "3",
       "train": ["4/6", "5"],
       "limit": 3,
+      "rounds": 2,
       "tiles": "brown",
       "events": {
         "close_companies": true
@@ -291,6 +294,7 @@
       "name": "4",
       "train": ["6", "7/8"],
       "limit": 2,
+      "rounds": 2,
       "tiles": "gray",
       "events": {
         "remove_tokens": true

--- a/games/1846.json
+++ b/games/1846.json
@@ -988,7 +988,7 @@
           }
         ],
         "removeBorders": [5],
-        "encoding": "o=r:yellow_30|brown_60;p=a:0,b:_0;l=E",
+        "encoding": "o=r:yellow_30|brown_60,h:1;p=a:0,b:_0;b=e:5",
         "hexes": ["C21"]
       },
       {
@@ -1025,7 +1025,7 @@
           ]
         },
         "removeBorders": [2],
-        "encoding": "o=r:yellow_30|brown_60;p=a:1,b:_0;l=E",
+        "encoding": "o=r:yellow_30|brown_60;p=a:1,b:_0;l=E;b=e:2",
         "hexes": ["D22"]
       },
       {
@@ -1231,7 +1231,7 @@
           }
         ],
         "removeBorders": [6],
-        "encoding": "o=r:yellow_30|brown_70;p=a:1,b:_0;l=E",
+        "encoding": "o=r:yellow_30|brown_70,h:1;p=a:1,b:_0;b=e:0",
         "hexes": ["F22"]
       },
       {
@@ -1388,7 +1388,7 @@
           ]
         },
         "removeBorders": [3],
-        "encoding": "o=r:yellow_30|brown_70;p=a:1,b:_0;p=a:2,b:_0;l=E",
+        "encoding": "o=r:yellow_30|brown_70;p=a:1,b:_0;p=a:2,b:_0;l=E;b=e:3",
         "hexes": ["G21"]
       },
       {

--- a/games/18Chesapeake.json
+++ b/games/18Chesapeake.json
@@ -1061,7 +1061,7 @@
         "cities": [
           {
             "companies": ["PLE"],
-            "group": "Pittsburgh"
+            "groups": ["Pittsburgh"]
           }
         ],
         "track": [
@@ -1099,7 +1099,7 @@
       {
         "color": "offboard",
         "offBoardRevenue": {
-          "group": "Pittsburgh",
+          "groups": ["Pittsburgh"],
           "name": {
             "name": "Pittsburgh"
           },
@@ -1182,7 +1182,7 @@
           "name": {
             "name": "West Virginia Coal"
           },
-          "group": "West Virginia Coal",
+          "groups": ["West Virginia Coal"],
           "revenues": [
             {
               "color": "yellow",
@@ -1222,7 +1222,7 @@
           "name": {
             "name": "West Virginia Coal"
           },
-          "group": "West Virginia Coal",
+          "groups": ["West Virginia Coal"],
           "revenues": [
             {
               "color": "yellow",

--- a/games/18Chesapeake.json
+++ b/games/18Chesapeake.json
@@ -1060,7 +1060,8 @@
         "color": "offboard",
         "cities": [
           {
-            "companies": ["PLE"]
+            "companies": ["PLE"],
+            "group": "Pittsburgh"
           }
         ],
         "track": [
@@ -1093,12 +1094,12 @@
             }
           ]
         },
-        "encoding": "c=r:yellow_40|green_50|brown_60|gray_80,h:1;p=a:5,b:_0",
         "hexes": ["A3"]
       },
       {
         "color": "offboard",
         "offBoardRevenue": {
+          "group": "Pittsburgh",
           "name": {
             "name": "Pittsburgh"
           },
@@ -1181,6 +1182,7 @@
           "name": {
             "name": "West Virginia Coal"
           },
+          "group": "West Virginia Coal",
           "revenues": [
             {
               "color": "yellow",
@@ -1220,6 +1222,7 @@
           "name": {
             "name": "West Virginia Coal"
           },
+          "group": "West Virginia Coal",
           "revenues": [
             {
               "color": "yellow",

--- a/games/18Chesapeake.json
+++ b/games/18Chesapeake.json
@@ -1093,7 +1093,7 @@
             }
           ]
         },
-        "encoding": "c=r:yellow_40|green_50|brown_60|gray_80;p=a:5,b:_0",
+        "encoding": "c=r:yellow_40|green_50|brown_60|gray_80,h:1;p=a:5,b:_0",
         "hexes": ["A3"]
       },
       {

--- a/games/public/1889.json
+++ b/games/public/1889.json
@@ -7,6 +7,7 @@
     "orientation": "horizontal",
     "titleX": 280,
     "titleY": 860,
+    "mustSellInBlocks": true,
     "currency": "¥#"
   },
   "links": {


### PR DESCRIPTION
Related:
* https://github.com/tobymao/18xx/pull/642
* https://github.com/18xx-maker/export-rb/pull/1

https://imgur.com/a/9JWnf15

Changes:

1817
- add incremental capitilization under "info"

1846
- add 2 rounds to each phase
- add incremental capitilization under "info"
- fix capitilization of city "Erie"
- update encoding for starting Chicago; remove all other encodings
- update offboards, etc for Buffalo and Pittsburgh
- add groups: Chicago, Buffalo, Pittsburgh, East

18Chesapeake
- add groups: Pittsburgh, West Virginia Coal
- remove all encodings
- add mustSellInBlocks under "info"