### PR TITLE
move labels for Pittsburgh and Buffalo

### DIFF
--- a/games/1846.json
+++ b/games/1846.json
@@ -982,13 +982,6 @@
             "side": 6
           }
         ],
-        "labels": [
-          {
-            "angle": 330,
-            "percent": 0.25,
-            "label": "E"
-          }
-        ],
         "offBoardRevenue": {
           "hidden": true,
           "groups": ["Buffalo", "East"],
@@ -1020,6 +1013,13 @@
           {
             "type": "offboard",
             "side": 1
+          }
+        ],
+        "labels": [
+          {
+            "angle": 150,
+            "percent": 0.5,
+            "label": "E"
           }
         ],
         "offBoardRevenue": {
@@ -1231,13 +1231,6 @@
       },
       {
         "color": "offboard",
-        "labels": [
-          {
-            "angle": 30,
-            "percent": 0.25,
-            "label": "E"
-          }
-        ],
         "track": [
           {
             "type": "offboard",
@@ -1373,6 +1366,13 @@
       },
       {
         "color": "offboard",
+        "labels": [
+          {
+            "angle": 210,
+            "percent": 0.5,
+            "label": "E"
+          }
+        ],
         "tunnels": [
           {
             "cost": 20,


### PR DESCRIPTION
better output for 18xx.games

before:

![Screenshot from 2020-06-06 16-14-25](https://user-images.githubusercontent.com/1045173/83955497-d2ee5800-a810-11ea-9671-9ca34646468c.png)

after:

![Screenshot from 2020-06-06 16-14-10](https://user-images.githubusercontent.com/1045173/83955502-df72b080-a810-11ea-80c2-9a311f9fb4c8.png)
